### PR TITLE
Changing the onBinaryContentAvailable prop to not be required

### DIFF
--- a/src/Pdf.js
+++ b/src/Pdf.js
@@ -206,7 +206,7 @@ Pdf.propTypes = {
   page: React.PropTypes.number,
   scale: React.PropTypes.number,
   onContentAvailable: React.PropTypes.func,
-  onBinaryContentAvailable: React.PropTypes.func.isRequired,
+  onBinaryContentAvailable: React.PropTypes.func,
   binaryToBase64: React.PropTypes.func,
   onDocumentComplete: React.PropTypes.func,
   onPageComplete: React.PropTypes.func,


### PR DESCRIPTION
Hi all, firstly, thanks for continuing this project - I was having some trouble with the now-broken `react-pdf` and `react-pdfjs` components, but have managed to get this working nicely.

I have no need for the binary content option right now (thus providing a URL), but it looks like the `onBinaryContentAvailable` prop is required even in this case.

In this commit I've removed `onBinaryContentAvailable` as a required prop. There is code to check if this prop is set in the `onDocumentComplete` method, so I can only guess this was a mistake (but if not, apologies!).