### PR TITLE
Fix PropType warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,8 @@
   "rules": {
     "consistent-return": "off",
     "react/forbid-prop-types": "off",
-    "no-bitwise": "off"
+    "no-bitwise": "off",
+    "react/no-unused-prop-types": [2, { skipShapeProps: true }]
   },
 
 }

--- a/src/Pdf.jsx
+++ b/src/Pdf.jsx
@@ -246,8 +246,12 @@ class Pdf extends React.Component {
 Pdf.displayName = 'react-pdf-js';
 Pdf.propTypes = {
   content: React.PropTypes.string,
-  documentInitParameters: React.PropTypes.shape,
-  binaryContent: React.PropTypes.shape,
+  documentInitParameters: React.PropTypes.shape({
+    url: React.PropTypes.string,
+  }),
+  binaryContent: React.PropTypes.shape({
+    data: React.PropTypes.any,
+  }),
   file: React.PropTypes.any, // Could be File object or URL string.
   loading: React.PropTypes.any,
   page: React.PropTypes.number,


### PR DESCRIPTION
* `React.PropTypes.shape` requires argument as per [documentation](https://facebook.github.io/react/docs/reusable-components.html#prop-validation)
* eslint rule `react/no-unused-prop-types` throws error even if it's used, stated on [documentation](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md)