### PR TITLE
Allow stretching of PDF to fill width or height

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ import PDF from 'react-pdf-js';
 
 class MyPdfViewer extends React.Component {
   state = {};
-  
+
   onDocumentComplete = (pages) => {
     this.setState({ page: 1, pages });
   }
@@ -77,6 +77,44 @@ class MyPdfViewer extends React.Component {
 module.exports = MyPdfViewer;
 ```
 
+## Scaling
+
+The PDF can be scaled in a couple of different ways.
+
+### Stretch to fill width/height
+
+Use the prop `fillWidth` to make the PDF stretch to the width of the parent element (generally speaking, this will be the enclosing `<div>`), or use `fillHeight` to do the same, but to the height of the PDF. The PDF will be scaled proportionately. Both `fillWidth` and `fillHeight` default to `false`.
+
+Note: `fillWidth` has precedence over `fillHeight`. So if you use both, the PDF will stretch to fill the width.
+
+Example:
+
+```js
+<div className="parentDivWhoseWidthAndHeightAreUsedToStretchThePdf">
+  <PDF
+    file="somefile.pdf"
+    fillWidth
+    fillHeight // this will be ignored because fillWidth is also passed
+  />
+</div>
+```
+
+### Set scale directly
+
+You can also set the scale manually by passing the `scale` prop. It defaults to `1`. A scale between `0` and `1` shrinks the PDF, and a scale greater than `1` enlarges.
+
+Note: if you use either `fillWidth` or `fillHeight` the value of `scale` will be ignored.
+
+Example:
+
+```js
+<div>
+  <PDF
+    file="somefile.pdf"
+    scale={1.5}
+  />
+</div>
+```
 
 ## Credit
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,12 @@ class MyPdfViewer extends React.Component {
     }
     return (
       <div>
-        <PDF file="somefile.pdf" onDocumentComplete={this.onDocumentComplete} onPageComplete={this.onPageComplete} page={this.state.page} />
+        <PDF
+          file="somefile.pdf"
+          onDocumentComplete={this.onDocumentComplete}
+          onPageComplete={this.onPageComplete}
+          page={this.state.page}
+        />
         {pagination}
       </div>
     )
@@ -83,7 +88,9 @@ The PDF can be scaled in a couple of different ways.
 
 ### Stretch to fill width/height
 
-Use the prop `fillWidth` to make the PDF stretch to the width of the parent element (generally speaking, this will be the enclosing `<div>`), or use `fillHeight` to do the same, but to the height of the PDF. The PDF will be scaled proportionately. Both `fillWidth` and `fillHeight` default to `false`.
+Use the prop `fillWidth` to make the PDF stretch to the width of the parent element (generally speaking, this will be the enclosing `<div>`), or use `fillHeight` to do the same for the height of the PDF. The PDF will be scaled proportionately.
+
+Both `fillWidth` and `fillHeight` default to `false`.
 
 Note: `fillWidth` has precedence over `fillHeight`. So if you use both, the PDF will stretch to fill the width.
 
@@ -101,9 +108,11 @@ Example:
 
 ### Set scale directly
 
-You can also set the scale manually by passing the `scale` prop. It defaults to `1`. A scale between `0` and `1` shrinks the PDF, and a scale greater than `1` enlarges.
+You can also set the scale manually by passing the `scale` prop. A `scale` between `0` and `1` shrinks the PDF, and a `scale` greater than `1` enlarges it.
 
-Note: if you use either `fillWidth` or `fillHeight` the value of `scale` will be ignored.
+`scale` defaults to `1`.
+
+Note: the value of `scale` will be ignored if you also use `fillWidth` or `fillHeight`.
 
 Example:
 

--- a/src/Pdf.jsx
+++ b/src/Pdf.jsx
@@ -23,14 +23,14 @@ const makeCancelable = (promise) => {
   };
 };
 
-const calculateScale = (scale, fillWidth, fillHeight, view) => {
+const calculateScale = (scale, fillWidth, fillHeight, view, parentElement) => {
   if (fillWidth) {
     const pageWidth = view[2] - view[0];
-    return window.innerWidth / pageWidth;
+    return parentElement.clientWidth / pageWidth;
   }
   if (fillHeight) {
     const pageHeight = view[3] - view[1];
-    return window.innerHeight / pageHeight;
+    return parentElement.clientHeight / pageHeight;
   }
   return scale;
 };
@@ -275,9 +275,10 @@ class Pdf extends React.Component {
         scale: pScale,
       } = this.props;
       const { canvas } = this;
+      const { parentElement } = canvas;
       const canvasContext = canvas.getContext('2d');
       const dpiScale = window.devicePixelRatio || 1;
-      const scale = calculateScale(pScale, fillWidth, fillHeight, page.view);
+      const scale = calculateScale(pScale, fillWidth, fillHeight, page.view, parentElement);
       const adjustedScale = scale * dpiScale;
       const viewport = page.getViewport(adjustedScale, rotate);
       canvas.style.width = `${viewport.width / dpiScale}px`;

--- a/src/Pdf.jsx
+++ b/src/Pdf.jsx
@@ -132,6 +132,10 @@ class Pdf extends React.Component {
   componentDidMount() {
     this.loadPDFDocument(this.props);
     this.renderPdf();
+
+    // re-scale PDF when size or orientation of window changes
+    window.addEventListener('resize', this.renderPdf);
+    window.addEventListener('orientationchange', this.renderPdf);
   }
 
   componentWillReceiveProps(newProps) {
@@ -175,6 +179,9 @@ class Pdf extends React.Component {
     if (this.documentPromise) {
       this.documentPromise.cancel();
     }
+
+    window.removeEventListener('resize', this.renderPdf);
+    window.removeEventListener('orientationchange', this.renderPdf);
   }
 
   onGetPdfRaw = (pdfRaw) => {

--- a/src/Pdf.jsx
+++ b/src/Pdf.jsx
@@ -48,8 +48,8 @@ class Pdf extends React.Component {
     loading: PropTypes.any,
     page: PropTypes.number,
     scale: PropTypes.number,
-    fillWidth: PropTypes.bool,
-    fillHeight: PropTypes.bool,
+    fillWidth: PropTypes.bool, // stretch to fill width, has precedence over fillHeight
+    fillHeight: PropTypes.bool, // stretch to fill height
     rotate: PropTypes.number,
     onContentAvailable: PropTypes.func,
     onBinaryContentAvailable: PropTypes.func,

--- a/src/Pdf.jsx
+++ b/src/Pdf.jsx
@@ -23,6 +23,18 @@ const makeCancelable = (promise) => {
   };
 };
 
+const calculateScale = (scale, fillWidth, fillHeight, view) => {
+  if (fillWidth) {
+    const pageWidth = view[2] - view[0];
+    return window.innerWidth / pageWidth;
+  }
+  if (fillHeight) {
+    const pageHeight = view[3] - view[1];
+    return window.innerHeight / pageHeight;
+  }
+  return scale;
+};
+
 class Pdf extends React.Component {
   static propTypes = {
     content: PropTypes.string,
@@ -36,6 +48,8 @@ class Pdf extends React.Component {
     loading: PropTypes.any,
     page: PropTypes.number,
     scale: PropTypes.number,
+    fillWidth: PropTypes.bool,
+    fillHeight: PropTypes.bool,
     rotate: PropTypes.number,
     onContentAvailable: PropTypes.func,
     onBinaryContentAvailable: PropTypes.func,
@@ -50,6 +64,8 @@ class Pdf extends React.Component {
   static defaultProps = {
     page: 1,
     scale: 1.0,
+    fillWidth: false,
+    fillHeight: false,
   };
 
   // Converts an ArrayBuffer directly to base64, without any intermediate 'convert to string then
@@ -252,10 +268,16 @@ class Pdf extends React.Component {
   renderPdf = () => {
     const { page } = this.state;
     if (page) {
+      const {
+        fillWidth,
+        fillHeight,
+        rotate,
+        scale: pScale,
+      } = this.props;
       const { canvas } = this;
       const canvasContext = canvas.getContext('2d');
       const dpiScale = window.devicePixelRatio || 1;
-      const { scale, rotate } = this.props;
+      const scale = calculateScale(pScale, fillWidth, fillHeight, page.view);
       const adjustedScale = scale * dpiScale;
       const viewport = page.getViewport(adjustedScale, rotate);
       canvas.style.width = `${viewport.width / dpiScale}px`;


### PR DESCRIPTION
This PR adds two props (`fillWidth` and `fillHeight`) that will stretch the PDF to the width or height of the parent element. Closes #41.

I also added a description of this new functionality to the `README`. Check out how those changes look [here](https://github.com/nikoladev/react-pdf-js/tree/fill-width-height).

This isn't a breaking change, so the version major shouldn't have to be bumped.