### PR TITLE
Use new canvas on each re-render

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,5 +127,5 @@ Example:
 
 ## Credit
 
-This project is a fork of [react-pdfjs](https://github.com/erikras/react-pdfjs) which itself was a port of [react-pdf](https://github.com/nnarhinen/react-pdf), so thank you to
+This project is a fork of [react-pdf-js](https://github.com/mikecousins/react-pdf-js) which itself was a fork of [react-pdfjs](https://github.com/erikras/react-pdfjs) which itself was a port of [react-pdf](https://github.com/nnarhinen/react-pdf), so thank you to
 the original authours.

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "react-pdf-js",
+  "name": "@andaleeb/react-pdf-js",
   "version": "3.0.3",
   "description": "A React component to wrap PDF.js",
   "main": "./lib/index.js",
   "jsnext:main": "./src/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mikecousins/react-pdf-js"
+    "url": "https://github.com/andaleebroomy/react-pdf-js"
   },
   "scripts": {
     "build": "npm run build:lib && npm run build:umd && npm run build:umd:min",
@@ -23,12 +23,12 @@
     "pdf",
     "pdfjs"
   ],
-  "author": "Mike Cousins <mike@mikecousins.com> (http://github.com/mikecousins)",
+  "author": "Syed Andaleeb Roomy <andaleebcse@gmail.com> (http://github.com/andaleebroomy)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mikecousins/react-pdf-js/issues"
+    "url": "https://github.com/andaleebroomy/react-pdf-js/issues"
   },
-  "homepage": "https://github.com/mikecousins/react-pdf-js",
+  "homepage": "https://github.com/andaleebroomy/react-pdf-js",
   "peerDependencies": {
     "react": ">=15.3",
     "react-dom": ">=15.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andaleeb/react-pdf-js",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A React component to wrap PDF.js",
   "main": "./lib/index.js",
   "jsnext:main": "./src/index.js",

--- a/src/Pdf.jsx
+++ b/src/Pdf.jsx
@@ -280,9 +280,25 @@ class Pdf extends React.Component {
         fillHeight,
         rotate,
         scale: pScale,
+        className,
+        style,
       } = this.props;
-      const { canvas } = this;
-      const { parentElement } = canvas;
+
+      // We need to create a new canvas every time in order to avoid concurrent rendering
+      // in the same canvas, which can lead to distorted or upside-down views.
+      const canvas = document.createElement('canvas');
+      canvas.style = style;
+      canvas.className = className;
+
+      // Replace or add the new canvas to the placehloder div set up in the render method.
+      const parentElement = this.canvasParent;
+      const previousCanvas = parentElement.firstChild;
+      if (previousCanvas) {
+        parentElement.replaceChild(canvas, previousCanvas);
+      } else {
+        parentElement.appendChild(canvas);
+      }
+
       const canvasContext = canvas.getContext('2d');
       const dpiScale = window.devicePixelRatio || 1;
       const scale = calculateScale(pScale, fillWidth, fillHeight, page.view, parentElement);
@@ -300,11 +316,8 @@ class Pdf extends React.Component {
     const { loading } = this.props;
     const { page } = this.state;
     return page ?
-      <canvas
-        ref={(c) => { this.canvas = c; }}
-        className={this.props.className}
-        style={this.props.style}
-      /> :
+      <div ref={(parentDiv) => { this.canvasParent = parentDiv; }} />
+      :
       loading || <div>Loading PDF...</div>;
   }
 }


### PR DESCRIPTION
During window resize or other events that trigger re-render of the PDF, if the same canvas is used by two or more quick successive render jobs, the resulting display can be distorted, e.g. sometimes text shows up as inverted/flipped/mirrored and sometimes it is blank, as shown in this screenshot:
![pdf text inverted](https://user-images.githubusercontent.com/16812877/34301692-cc56d278-e757-11e7-8bab-f199a4a2454f.PNG)

As suggested in the following comment in pdf.js project, it has to be solved either by using a new canvas for each re-render, or by waiting for current render to complete.
https://github.com/mozilla/pdf.js/issues/2923#issuecomment-14715851

Using a new canvas seems quicker and easier to implement in this case. This pull request is about fixing it in this way.

In order to be able to have a handle on where to inject the new canvas, a new placeholder parent div is introduced in the React render method. on renderPdf, a new canvas is created and added/replaced in this div as its child.

This could potentially solve the following issue:
#22 