### PR TITLE
fixed styles given as props to be merged to canvas properly

### DIFF
--- a/src/Pdf.jsx
+++ b/src/Pdf.jsx
@@ -287,7 +287,10 @@ class Pdf extends React.Component {
       // We need to create a new canvas every time in order to avoid concurrent rendering
       // in the same canvas, which can lead to distorted or upside-down views.
       const canvas = document.createElement('canvas');
-      canvas.style = style;
+
+      Object.keys(style || {}).forEach((styleField) => {
+        canvas.style[styleField] = style[styleField];
+      });
       canvas.className = className;
 
       // Replace or add the new canvas to the placehloder div set up in the render method.


### PR DESCRIPTION
Fixing one of the two problems reported in #56 . Element's style can't be assigned to (and on IE it throws an error in strict mode) so using the style prop didn't work at all in any browser.

This PR fixes the issue by assigning to the individual fields of the style object directly.