### PR TITLE
Reverts pdf-dist dep version to 2.0.203  - issue #60

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "webpack": "^2.0.0 || ^3.0.0"
   },
   "dependencies": {
-    "pdfjs-dist": "^2.0.303",
+    "pdfjs-dist": "^2.0.203",
     "prop-types": "^15.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Relates to https://github.com/mikecousins/react-pdf-js/issues/60 
