### PR TITLE
Adding `workerSrc` prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ export default class ReactPdfJs extends Component {
     cMapUrl: PropTypes.string,
     cMapPacked: PropTypes.bool,
     className: PropTypes.string,
+    workerSrc: PropTypes.string,
   }
 
   static defaultProps = {
@@ -25,6 +26,7 @@ export default class ReactPdfJs extends Component {
     scale: 1,
     cMapUrl: '../node_modules/pdfjs-dist/cmaps/',
     cMapPacked: false,
+    workerSrc: '//cdnjs.cloudflare.com/ajax/libs/pdf.js/2.0.943/pdf.worker.js',
   }
 
   state = {
@@ -38,8 +40,9 @@ export default class ReactPdfJs extends Component {
       page,
       cMapUrl,
       cMapPacked,
+      workerSrc,
     } = this.props;
-    PdfJsLib.GlobalWorkerOptions.workerSrc = '//cdnjs.cloudflare.com/ajax/libs/pdf.js/2.0.943/pdf.worker.js';
+    PdfJsLib.GlobalWorkerOptions.workerSrc = workerSrc;
     PdfJsLib.getDocument({ url: file, cMapUrl, cMapPacked }).then((pdf) => {
       this.setState({ pdf });
       if (onDocumentComplete) {


### PR DESCRIPTION
Adding `workerSrc` prop to main component to facilitate providing own worker file.

This is particularly useful when needing to support IE11 where the user may have heightened security in place.

#88 