### PR TITLE
Improve Pdf component

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,43 +1,44 @@
 import 'react-app-polyfill/ie11';
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { render } from 'react-dom';
-import { usePdf } from '../.';
+
+import Pdf from '../.';
 import './pdfs/basic.pdf';
 
 const App = () => {
   const [page, setPage] = useState(1);
-  const canvasEl = useRef(null);
-
-  const [loading, pages] = usePdf({
-    file: 'basic.33e35a62.pdf',
-    page,
-    canvasEl,
-  });
 
   return (
-    <div>
-      {loading && <span>Loading...</span>}
-      <canvas ref={canvasEl} />
-      {Boolean(pages) && (
-        <nav>
-          <ul className="pager">
-            <li className="previous">
-              <button disabled={page === 1} onClick={() => setPage(page - 1)}>
-                Previous
-              </button>
-            </li>
-            <li className="next">
-              <button
-                disabled={page === pages}
-                onClick={() => setPage(page + 1)}
-              >
-                Next
-              </button>
-            </li>
-          </ul>
-        </nav>
+    <Pdf file="basic.33e35a62.pdf" page={page}>
+      {({ pdfDocument, canvas }) => (
+        <>
+          {!pdfDocument && <span>Loading...</span>}
+          {canvas}
+          {Boolean(pdfDocument?.numPages) && (
+            <nav>
+              <ul className="pager">
+                <li className="previous">
+                  <button
+                    disabled={page === 1}
+                    onClick={() => setPage(page - 1)}
+                  >
+                    Previous
+                  </button>
+                </li>
+                <li className="next">
+                  <button
+                    disabled={page === pdfDocument?.numPages}
+                    onClick={() => setPage(page + 1)}
+                  >
+                    Next
+                  </button>
+                </li>
+              </ul>
+            </nav>
+          )}
+        </>
       )}
-    </div>
+    </Pdf>
   );
 };
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "tsdx build",
     "test": "tsdx test --env=jsdom",
     "test:coverage": "CI=true tsdx test --color --coverage",
-    "lint": "tsdx lint src",
+    "lint": "tsdx lint src test",
     "netlify": "yarn && yarn build && cd example && yarn && yarn build"
   },
   "peerDependencies": {
@@ -24,7 +24,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "tsdx lint src"
+      "pre-commit": "tsdx lint src test"
     }
   },
   "prettier": {
@@ -33,6 +33,11 @@
     "singleQuote": true,
     "trailingComma": "es5"
   },
+  "jest": {
+    "setupFiles": [
+      "jest-canvas-mock"
+    ]
+  },
   "devDependencies": {
     "@testing-library/react": "9.4.0",
     "@types/jest": "24.0.25",
@@ -40,6 +45,7 @@
     "@types/react": "16.9.17",
     "@types/react-dom": "16.9.4",
     "husky": "3.1.0",
+    "jest-canvas-mock": "^2.2.0",
     "react": "16.12.0",
     "react-dom": "16.12.0",
     "tsdx": "0.12.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,29 @@
 import pdfjs from 'pdfjs-dist';
 import React, { useState, useEffect, useRef, useImperativeHandle } from 'react';
 
-type ComponentProps = Omit<HookProps, 'canvasEl'> &
-  React.CanvasHTMLAttributes<HTMLCanvasElement>;
+function isFunction(value: any): value is Function {
+  return typeof value === 'function';
+}
+
+type ComponentRenderProps = HookReturnValues & {
+  canvas: React.ReactElement;
+};
+
+type ComponentProps = Omit<HookProps, 'canvasRef'> &
+  React.CanvasHTMLAttributes<HTMLCanvasElement> & {
+    children?: (renderProps: ComponentRenderProps) => React.ReactElement;
+  };
 
 const Pdf = React.forwardRef<HTMLCanvasElement | null, ComponentProps>(
   (
     {
       file,
-      onPageLoaded,
+      onDocumentLoadSuccess,
+      onDocumentLoadFail,
+      onPageLoadSuccess,
+      onPageLoadFail,
+      onPageRenderSuccess,
+      onPageRenderFail,
       page,
       scale,
       rotate,
@@ -16,17 +31,23 @@ const Pdf = React.forwardRef<HTMLCanvasElement | null, ComponentProps>(
       cMapPacked,
       workerSrc,
       withCredentials,
+      children,
       ...canvasProps
     },
     ref
   ) => {
-    const canvasEl = useRef<HTMLCanvasElement>(null);
-    useImperativeHandle(ref, () => canvasEl.current);
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    useImperativeHandle(ref, () => canvasRef.current);
 
-    usePdf({
-      canvasEl,
+    const pdfData = usePdf({
+      canvasRef,
       file,
-      onPageLoaded,
+      onDocumentLoadSuccess,
+      onDocumentLoadFail,
+      onPageLoadSuccess,
+      onPageLoadFail,
+      onPageRenderSuccess,
+      onPageRenderFail,
       page,
       scale,
       rotate,
@@ -36,14 +57,25 @@ const Pdf = React.forwardRef<HTMLCanvasElement | null, ComponentProps>(
       withCredentials,
     });
 
-    return <canvas {...canvasProps} ref={canvasEl} />;
+    const canvas = <canvas {...canvasProps} ref={canvasRef} />;
+
+    if (isFunction(children)) {
+      return children({ canvas, ...pdfData });
+    }
+
+    return canvas;
   }
 );
 
 type HookProps = {
-  canvasEl: React.RefObject<HTMLCanvasElement>;
+  canvasRef: React.RefObject<HTMLCanvasElement | null>;
   file: string;
-  onPageLoaded?: () => void;
+  onDocumentLoadSuccess?: (document: pdfjs.PDFDocumentProxy) => void;
+  onDocumentLoadFail?: () => void;
+  onPageLoadSuccess?: (page: pdfjs.PDFPageProxy) => void;
+  onPageLoadFail?: () => void;
+  onPageRenderSuccess?: (page: pdfjs.PDFPageProxy) => void;
+  onPageRenderFail?: () => void;
   scale?: number;
   rotate?: number;
   page?: number;
@@ -53,12 +85,20 @@ type HookProps = {
   withCredentials?: boolean;
 };
 
-type HookReturnValues = [boolean, number | null];
+type HookReturnValues = {
+  pdfDocument: pdfjs.PDFDocumentProxy | undefined;
+  pdfPage: pdfjs.PDFPageProxy | undefined;
+};
 
 export const usePdf = ({
-  canvasEl,
+  canvasRef,
   file,
-  onPageLoaded,
+  onDocumentLoadSuccess,
+  onDocumentLoadFail,
+  onPageLoadSuccess,
+  onPageLoadFail,
+  onPageRenderSuccess,
+  onPageRenderFail,
   scale = 1,
   rotate = 0,
   page = 1,
@@ -67,8 +107,40 @@ export const usePdf = ({
   workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`,
   withCredentials = false,
 }: HookProps): HookReturnValues => {
-  const [pdf, setPdf] = useState<pdfjs.PDFDocumentProxy>();
+  const [pdfDocument, setPdfDocument] = useState<pdfjs.PDFDocumentProxy>();
+  const [pdfPage, setPdfPage] = useState<pdfjs.PDFPageProxy>();
   const renderTask = useRef<pdfjs.PDFRenderTask | null>(null);
+  const onDocumentLoadSuccessRef = useRef(onDocumentLoadSuccess);
+  const onDocumentLoadFailRef = useRef(onDocumentLoadFail);
+  const onPageLoadSuccessRef = useRef(onPageLoadSuccess);
+  const onPageLoadFailRef = useRef(onPageLoadFail);
+  const onPageRenderSuccessRef = useRef(onPageRenderSuccess);
+  const onPageRenderFailRef = useRef(onPageRenderFail);
+
+  // assign callbacks to refs to avoid redrawing
+  useEffect(() => {
+    onDocumentLoadSuccessRef.current = onDocumentLoadSuccess;
+  }, [onDocumentLoadSuccess]);
+
+  useEffect(() => {
+    onDocumentLoadFailRef.current = onDocumentLoadFail;
+  }, [onDocumentLoadFail]);
+
+  useEffect(() => {
+    onPageLoadSuccessRef.current = onPageLoadSuccess;
+  }, [onPageLoadSuccess]);
+
+  useEffect(() => {
+    onPageLoadFailRef.current = onPageLoadFail;
+  }, [onPageLoadFail]);
+
+  useEffect(() => {
+    onPageRenderSuccessRef.current = onPageRenderSuccess;
+  }, [onPageRenderSuccess]);
+
+  useEffect(() => {
+    onPageRenderFailRef.current = onPageRenderFail;
+  }, [onPageRenderFail]);
 
   useEffect(() => {
     pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
@@ -80,10 +152,22 @@ export const usePdf = ({
       config.cMapUrl = cMapUrl;
       config.cMapPacked = cMapPacked;
     }
-    pdfjs.getDocument(config).promise.then(setPdf);
+    pdfjs.getDocument(config).promise.then(
+      loadedPdfDocument => {
+        setPdfDocument(loadedPdfDocument);
+
+        if (isFunction(onDocumentLoadSuccessRef.current)) {
+          onDocumentLoadSuccessRef.current(loadedPdfDocument);
+        }
+      },
+      () => {
+        if (isFunction(onDocumentLoadFailRef.current)) {
+          onDocumentLoadFailRef.current();
+        }
+      }
+    );
   }, [file, withCredentials, cMapUrl, cMapPacked]);
 
-  // handle changes
   useEffect(() => {
     // draw a page of the pdf
     const drawPDF = (page: pdfjs.PDFPageProxy) => {
@@ -93,20 +177,20 @@ export const usePdf = ({
       const dpRatio = window.devicePixelRatio;
       const adjustedScale = scale * dpRatio;
       const viewport = page.getViewport({ scale: adjustedScale, rotation });
-      const canvas = canvasEl.current;
-      if (!canvas) {
+      const canvasEl = canvasRef.current;
+      if (!canvasEl) {
         return;
       }
 
-      const canvasContext = canvas.getContext('2d');
+      const canvasContext = canvasEl.getContext('2d');
       if (!canvasContext) {
         return;
       }
 
-      canvas.style.width = `${viewport.width / dpRatio}px`;
-      canvas.style.height = `${viewport.height / dpRatio}px`;
-      canvas.height = viewport.height;
-      canvas.width = viewport.width;
+      canvasEl.style.width = `${viewport.width / dpRatio}px`;
+      canvasEl.style.height = `${viewport.height / dpRatio}px`;
+      canvasEl.height = viewport.height;
+      canvasEl.width = viewport.width;
 
       // if previous render isn't done yet, we cancel it
       if (renderTask.current) {
@@ -123,30 +207,44 @@ export const usePdf = ({
         () => {
           renderTask.current = null;
 
-          if (typeof onPageLoaded === 'function') {
-            onPageLoaded();
+          if (isFunction(onPageRenderSuccessRef.current)) {
+            onPageRenderSuccessRef.current(page);
           }
         },
         err => {
           renderTask.current = null;
 
           // @ts-ignore typings are outdated
-          if (err.name === 'RenderingCancelledException') {
+          if (err && err.name === 'RenderingCancelledException') {
             drawPDF(page);
+          } else if (isFunction(onPageRenderFailRef.current)) {
+            onPageRenderFailRef.current();
           }
         }
       );
     };
 
-    if (pdf) {
-      pdf.getPage(page).then(drawPDF);
+    if (pdfDocument) {
+      pdfDocument.getPage(page).then(
+        loadedPdfPage => {
+          setPdfPage(loadedPdfPage);
+
+          if (isFunction(onPageLoadSuccessRef.current)) {
+            onPageLoadSuccessRef.current(loadedPdfPage);
+          }
+
+          drawPDF(loadedPdfPage);
+        },
+        () => {
+          if (isFunction(onPageLoadFailRef.current)) {
+            onPageLoadFailRef.current();
+          }
+        }
+      );
     }
-  }, [pdf, page, scale, rotate, canvasEl, onPageLoaded]);
+  }, [canvasRef, page, pdfDocument, rotate, scale]);
 
-  const loading = !pdf;
-  const numPages = pdf ? pdf.numPages : null;
-
-  return [loading, numPages];
+  return { pdfDocument, pdfPage };
 };
 
 export default Pdf;

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -1,12 +1,154 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import pdfjs from 'pdfjs-dist';
+import { render, wait, waitForDomChange } from '@testing-library/react';
 
 import Pdf from '../src';
 
-describe('Pdf', () => {
-  it('renders without crashing', () => {
-    const { container } = render(<Pdf file="basic.33e35a62.pdf" />);
+jest.mock('pdfjs-dist', () => ({
+  version: '1.0',
+  GlobalWorkerOptions: {
+    workerSrc: '',
+  },
+  getDocument: jest.fn((config: pdfjs.PDFSource) => ({
+    promise: config.url?.includes('fail_document')
+      ? Promise.reject()
+      : Promise.resolve({
+          getPage: jest.fn(() =>
+            config.url?.includes('fail_page')
+              ? Promise.reject()
+              : Promise.resolve({
+                  getViewport: jest.fn(() => ({ width: 0, height: 0 })),
+                  render: jest.fn(() => ({
+                    promise: config.url?.includes('fail_render')
+                      ? Promise.reject()
+                      : Promise.resolve(),
+                  })),
+                })
+          ),
+        }),
+  })),
+}));
 
-    expect(container).toBeDefined();
+describe('Pdf', () => {
+  it('renders children', async () => {
+    const { getByText } = render(
+      <Pdf file="basic.33e35a62.pdf">
+        {({ canvas }) => (
+          <div>
+            {canvas}
+            <div>Test</div>
+          </div>
+        )}
+      </Pdf>
+    );
+
+    await waitForDomChange();
+
+    getByText('Test');
+  });
+
+  it('calls render function with proper params', async () => {
+    const renderFunc = jest.fn(({ canvas }) => canvas);
+
+    render(<Pdf file="basic.33e35a62.pdf">{renderFunc}</Pdf>);
+
+    expect(renderFunc).toBeCalledWith({
+      canvas: expect.any(Object),
+      pdfDocument: undefined,
+      pdfPage: undefined,
+    });
+
+    await wait();
+
+    expect(renderFunc).toBeCalledWith({
+      canvas: expect.any(Object),
+      pdfDocument: expect.any(Object),
+      pdfPage: expect.any(Object),
+    });
+  });
+
+  describe('callbacks', () => {
+    const onDocLoadSuccess = jest.fn();
+    const onDocLoadFail = jest.fn();
+    const onPageLoadSuccess = jest.fn();
+    const onPageLoadFail = jest.fn();
+    const onPageRenderSuccess = jest.fn();
+    const onPageRenderFail = jest.fn();
+
+    beforeEach(() => {
+      onDocLoadSuccess.mockClear();
+      onDocLoadFail.mockClear();
+      onPageLoadSuccess.mockClear();
+      onPageLoadFail.mockClear();
+      onPageRenderSuccess.mockClear();
+      onPageRenderFail.mockClear();
+    });
+
+    const renderPdf = (file: string) =>
+      render(
+        <Pdf
+          file={file}
+          onDocumentLoadSuccess={onDocLoadSuccess}
+          onDocumentLoadFail={onDocLoadFail}
+          onPageLoadSuccess={onPageLoadSuccess}
+          onPageLoadFail={onPageLoadFail}
+          onPageRenderSuccess={onPageRenderSuccess}
+          onPageRenderFail={onPageRenderFail}
+        >
+          {({ canvas }) => canvas}
+        </Pdf>
+      );
+
+    it('calls proper callbacks when fully successful', async () => {
+      renderPdf('basic.33e35a62.pdf');
+
+      await wait();
+
+      expect(onDocLoadSuccess).toBeCalledWith(expect.any(Object));
+      expect(onDocLoadFail).not.toBeCalled();
+      expect(onPageLoadSuccess).toBeCalledWith(expect.any(Object));
+      expect(onPageLoadFail).not.toBeCalled();
+      expect(onPageRenderSuccess).toBeCalledWith(expect.any(Object));
+      expect(onPageRenderFail).not.toBeCalled();
+    });
+
+    it('calls proper callbacks when render failed', async () => {
+      renderPdf('fail_render');
+
+      await wait();
+
+      expect(onDocLoadSuccess).toBeCalledWith(expect.any(Object));
+      expect(onDocLoadFail).not.toBeCalled();
+      expect(onPageLoadSuccess).toBeCalledWith(expect.any(Object));
+      expect(onPageLoadFail).not.toBeCalled();
+      expect(onPageRenderSuccess).not.toBeCalled();
+      expect(onPageRenderFail).toBeCalled();
+    });
+
+    it('calls proper callbacks when page load failed', async () => {
+      renderPdf('fail_page');
+
+      await wait();
+
+      expect(onDocLoadSuccess).toBeCalledWith(expect.any(Object));
+      expect(onDocLoadFail).not.toBeCalled();
+      expect(onPageLoadSuccess).not.toBeCalled();
+      expect(onPageLoadFail).toBeCalled();
+      expect(onPageRenderSuccess).not.toBeCalled();
+      expect(onPageRenderFail).not.toBeCalled();
+    });
+
+    it('calls proper callbacks when document load failed', async () => {
+      renderPdf('fail_document');
+
+      await wait();
+
+      expect(onDocLoadSuccess).not.toBeCalled();
+      expect(onDocLoadFail).toBeCalled();
+      expect(onPageLoadSuccess).not.toBeCalled();
+      expect(onPageLoadFail).not.toBeCalled();
+      expect(onPageRenderSuccess).not.toBeCalled();
+      expect(onPageRenderFail).not.toBeCalled();
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1866,6 +1866,11 @@ color-convert@^1.9.0:
   dependencies:
     color-name "1.1.3"
 
+color-convert@~0.5.0:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd"
+  integrity sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
@@ -1990,6 +1995,11 @@ cross-spawn@^7.0.0:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+cssfontparser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cssfontparser/-/cssfontparser-1.2.1.tgz#f4022fc8f9700c68029d542084afbaf425a3f3e3"
+  integrity sha1-9AIvyPlwDGgCnVQghK+69CWj8+M=
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.8"
@@ -3315,6 +3325,14 @@ istanbul-reports@^2.2.6:
   dependencies:
     handlebars "^4.1.2"
 
+jest-canvas-mock@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.2.0.tgz#45fbc58589c6ce9df50dc90bd8adce747cbdada7"
+  integrity sha512-DcJdchb7eWFZkt6pvyceWWnu3lsp5QWbUeXiKgEMhwB3sMm5qHM1GQhDajvJgBeiYpgKcojbzZ53d/nz6tXvJw==
+  dependencies:
+    cssfontparser "^1.2.1"
+    parse-color "^1.0.0"
+
 jest-changed-files@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.9.0.tgz#08d8c15eb79a7fa3fc98269bc14b451ee82f8039"
@@ -4472,6 +4490,13 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parse-color@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-color/-/parse-color-1.0.0.tgz#7b748b95a83f03f16a94f535e52d7f3d94658619"
+  integrity sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=
+  dependencies:
+    color-convert "~0.5.0"
 
 parse-json@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
I've spent some time to improve the `Pdf` component and the `usePdf` hook.

A summary of what I did:
- Changes the return values of the hook. It returns `pdfjs`'s proxy objects now - this way it's possible to use embedded data after the document/page were loaded or rendered
- Added children render prop to the component
- Added multiple callbacks to the hook (callback ref change won't cause redrawing the pdf)
- Adjusted naming
- Adjusted readme and added examples
- Added some basic tests

I believe that below changes address #163 and #113.

Looking forward to comments of all kind.