### PR TITLE
Fix race condition: Render last requested page

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "trailingComma": "es5"
   },
   "devDependencies": {
+    "eslint": "^8.33.0",
     "prettier": "2.7.1",
     "turbo": "1.4.7",
     "typescript": "4.8.3"

--- a/packages/react-pdf-js/src/index.tsx
+++ b/packages/react-pdf-js/src/index.tsx
@@ -52,6 +52,7 @@ export const usePdf = ({
   const [pdfDocument, setPdfDocument] = useState<PDFDocumentProxy>();
   const [pdfPage, setPdfPage] = useState<PDFPageProxy>();
   const renderTask = useRef<PDFRenderTask | null>(null);
+  const lastPageRequestedRenderRef = useRef<PDFPageProxy | null>(null);
   const onDocumentLoadSuccessRef = useRef(onDocumentLoadSuccess);
   const onDocumentLoadFailRef = useRef(onDocumentLoadFail);
   const onPageLoadSuccessRef = useRef(onPageLoadSuccess);
@@ -137,6 +138,7 @@ export const usePdf = ({
 
       // if previous render isn't done yet, we cancel it
       if (renderTask.current) {
+        lastPageRequestedRenderRef.current = page;
         renderTask.current.cancel();
         return;
       }
@@ -158,7 +160,9 @@ export const usePdf = ({
           renderTask.current = null;
 
           if (reason && reason.name === 'RenderingCancelledException') {
-            drawPDF(page);
+            const lastPageRequestedRender = lastPageRequestedRenderRef.current ?? page;
+            lastPageRequestedRenderRef.current = null;
+            drawPDF(lastPageRequestedRender);
           } else if (isFunction(onPageRenderFailRef.current)) {
             onPageRenderFailRef.current();
           }


### PR DESCRIPTION
Test Plan: Copy into local project and quickly change pages. Ensure that the correct page gets rendered. Run the demo app with the following changes to observe the issue and test the fix

```tsx
  useEffect(() => {
    for (let i = 0; i < 8; i++) {
      const pgNum = (i % 2) + 8;

      setTimeout(() => {
        setPage(pgNum);
      }, i * 100);
    }
  }, []);

  const { pdfDocument } = usePdf({
    file: 'plan.pdf',
    page,
    canvasRef,
    scale: 1.5,
    onPageRenderSuccess: page => {
      console.log("Render success:", page.pageNumber);
    }
  });
  console.log("Set page:", page);
```

Without these changes:
```
Set page: 8
Set page: 9
Set page: 8
Set page: 9
Set page: 8
Set page: 9
Set page: 8
Set page: 9
Render success: 8
```

With these changes:
```
Set page: 8
Set page: 9
Set page: 8
Set page: 9
Set page: 8
Set page: 9
Set page: 8
Set page: 9
Render success: 9
```

Note that I did  have to use a pdf with pages that required a lot of rendering as well as a high scale in order to reproduce the issue