### PR TITLE
refactor: make drawPdf function less opinionated

### DIFF
--- a/packages/react-pdf-js/src/index.tsx
+++ b/packages/react-pdf-js/src/index.tsx
@@ -117,9 +117,7 @@ export const usePdf = ({
       // Because this page's rotation option overwrites pdf default rotation value,
       // calculating page rotation option value from pdf default and this component prop rotate.
       const rotation = rotate === 0 ? page.rotate : page.rotate + rotate;
-      const dpRatio = window.devicePixelRatio;
-      const adjustedScale = scale * dpRatio;
-      const viewport = page.getViewport({ scale: adjustedScale, rotation });
+      const viewport = page.getViewport({ scale, rotation });
       const canvasEl = canvasRef!.current;
       if (!canvasEl) {
         return;
@@ -129,9 +127,7 @@ export const usePdf = ({
       if (!canvasContext) {
         return;
       }
-
-      canvasEl.style.width = `${viewport.width / dpRatio}px`;
-      canvasEl.style.height = `${viewport.height / dpRatio}px`;
+      
       canvasEl.height = viewport.height;
       canvasEl.width = viewport.width;
 

--- a/packages/react-pdf-js/src/index.tsx
+++ b/packages/react-pdf-js/src/index.tsx
@@ -128,8 +128,10 @@ export const usePdf = ({
         return;
       }
       
-      canvasEl.height = viewport.height;
-      canvasEl.width = viewport.width;
+      canvasEl.height = viewport.height * window.devicePixelRatio;
+      canvasEl.width = viewport.width * window.devicePixelRatio;
+
+      canvasContext.scale(window.devicePixelRatio, window.devicePixelRatio);
 
       // if previous render isn't done yet, we cancel it
       if (renderTask.current) {


### PR DESCRIPTION
I think drawPdf should leave the styling and scale of the pdf to the hook caller.  

Setting the canvas height and width is fine for displaying the PDF since the canvas is taking on the height and width of the PDF. The canvas element that uses the hook can be styled in any fashion through class name or style.

This also provides a solution to #405.

---

Before this change, the scale was only applied to the pdfjs-generated viewport, this instead applies the scale to the canvas. Referenced from this SOF: https://stackoverflow.com/a/5306929/4771642
