### PR TITLE
Push tag to origin in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
           name="$(jq -r '.[0].name' <<<"$PUBLISHED")"
           version="$(jq -r '.[0].version' <<<"$PUBLISHED")"
           tag="${name}@${version}"
+          git push origin "refs/tags/${tag}"
           awk -v v="$version" '
             $0 == "## " v { flag = 1; next }
             /^## / && flag { flag = 0 }


### PR DESCRIPTION
## Summary

- Fixes the release workflow that failed on the 8.1.1 merge ([run 26316367169](https://github.com/mikecousins/react-pdf-js/actions/runs/26316367169)) with `tag @mikecousins/react-pdf@8.1.1 exists locally but has not been pushed to mikecousins/react-pdf-js`.
- `changesets/action`'s `pnpm exec changeset tag` step creates the tag on the runner but, in that run, did not push it to origin — so the immediately following `gh release create` refused to create a release.
- Adds one line to the `Create draft GitHub Release` step that explicitly pushes the tag to `origin` before `gh release create`. Idempotent — if `changesets/action` ever pushes the tag itself, this is a no-op.
- The stuck 8.1.1 release has already been recovered out-of-band: tag pushed manually and draft release created at https://github.com/mikecousins/react-pdf-js/releases — publishing that draft will fire `publish.yml` and push 8.1.1 to npm.

## Test plan

- [ ] Merge this PR.
- [ ] Publish the existing 8.1.1 draft release to confirm `publish.yml` succeeds (independent of this fix; not gated on this PR).
- [ ] On the next changeset-driven release, confirm the new tag appears in `git ls-remote --tags origin` *and* the draft GitHub Release is created without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)